### PR TITLE
Fix sentinel fmt

### DIFF
--- a/src/sentinel_fmt.sh
+++ b/src/sentinel_fmt.sh
@@ -5,7 +5,8 @@
 function sentinelFmt {
   # Gather the output of `sentinel fmt`.
   echo "fmt: info: checking if Sentinel files in ${stlWorkingDir} are correctly formatted"
-  fmtOutput=$(sentinel fmt -check=true $(find ${stlWorkingDir} -name "*.sentinel" -type f) 2>&1)
+  fileList=$(find ${stlWorkingDir} -name "*.sentinel" -type f)
+  fmtOutput=$(sentinel fmt -check=true ${fileList} 2>&1)
   fmtExitCode=${?}
 
   # Exit code of 0 indicates success. Print the output and exit.
@@ -29,7 +30,8 @@ function sentinelFmt {
   echo "${fmtOutput}"
   echo
   echo "fmt: error: the following files in ${stlWorkingDir} are incorrectly formatted"
-  fmtFileList=$(sentinel fmt -check=true -write=false $(find ${stlWorkingDir} -name "*.sentinel" -type f))
+  fileList=$(find ${stlWorkingDir} -name "*.sentinel" -type f)
+  fmtFileList=$(sentinel fmt -check=true -write=false ${fileList})
   echo "${fmtFileList}"
   echo
 

--- a/src/sentinel_fmt.sh
+++ b/src/sentinel_fmt.sh
@@ -1,12 +1,11 @@
-#!/bin/bash
+#!/bin/bash -x
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
-
 
 function sentinelFmt {
   # Gather the output of `sentinel fmt`.
   echo "fmt: info: checking if Sentinel files in ${stlWorkingDir} are correctly formatted"
-  fmtOutput=$(sentinel fmt -check=true -write=false ${*} 2>&1)
+  fmtOutput=$(sentinel fmt -check=true $(find ${stlWorkingDir} -name "*.sentinel" -type f) 2>&1)
   fmtExitCode=${?}
 
   # Exit code of 0 indicates success. Print the output and exit.
@@ -30,7 +29,7 @@ function sentinelFmt {
   echo "${fmtOutput}"
   echo
   echo "fmt: error: the following files in ${stlWorkingDir} are incorrectly formatted"
-  fmtFileList=$(sentinel fmt -check=true -write=false ${stlWorkingDir})
+  fmtFileList=$(sentinel fmt -check=true -write=false $(find ${stlWorkingDir} -name "*.sentinel" -type f))
   echo "${fmtFileList}"
   echo
 
@@ -57,7 +56,7 @@ ${fmtComment}
     fmtPayload=$(echo "${fmtCommentWrapper}" | jq -R --slurp '{body: .}')
     fmtCommentsURL=$(cat ${GITHUB_EVENT_PATH} | jq -r .pull_request.comments_url)
     echo "fmt: info: commenting on the pull request"
-    echo "${fmtPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${fmtCommentsURL}" > /dev/null
+    echo "${fmtPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${fmtCommentsURL}" >/dev/null
   fi
 
   exit ${fmtExitCode}

--- a/src/sentinel_fmt.sh
+++ b/src/sentinel_fmt.sh
@@ -5,7 +5,7 @@
 function sentinelFmt {
   # Gather the output of `sentinel fmt`.
   echo "fmt: info: checking if Sentinel files in ${stlWorkingDir} are correctly formatted"
-  fileList=$(find . -name "*.sentinel" -type f)
+  fileList=$(find . -name "*.sentinel" -type f -not -path "./test/*")
   fmtOutput=$(sentinel fmt -check=true ${fileList} 2>&1)
   fmtExitCode=${?}
 

--- a/src/sentinel_fmt.sh
+++ b/src/sentinel_fmt.sh
@@ -5,7 +5,7 @@
 function sentinelFmt {
   # Gather the output of `sentinel fmt`.
   echo "fmt: info: checking if Sentinel files in ${stlWorkingDir} are correctly formatted"
-  fileList=$(find ${stlWorkingDir} -name "*.sentinel" -type f)
+  fileList=$(find . -name "*.sentinel" -type f)
   fmtOutput=$(sentinel fmt -check=true ${fileList} 2>&1)
   fmtExitCode=${?}
 
@@ -30,7 +30,7 @@ function sentinelFmt {
   echo "${fmtOutput}"
   echo
   echo "fmt: error: the following files in ${stlWorkingDir} are incorrectly formatted"
-  fileList=$(find ${stlWorkingDir} -name "*.sentinel" -type f)
+  fileList=$(find . -name "*.sentinel" -type f)
   fmtFileList=$(sentinel fmt -check=true -write=false ${fileList})
   echo "${fmtFileList}"
   echo


### PR DESCRIPTION
Code to fix the `sentinel fmt` failure because the command expects file paths, not a directory path. Also, it excludes the `test/` subdirectory from the format check.